### PR TITLE
Prepends the path of the Python source file to each line pointing to …

### DIFF
--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -144,7 +144,8 @@ class MypyItem(pytest.Item):
         full exception repr.
         """
         if excinfo.errisinstance(MypyError):
-            return excinfo.value.args[0]
+            return '\n'.join(
+                f'{self.fspath}:{line}' for line in excinfo.value.args[0].splitlines())
         return super().repr_failure(excinfo)
 
 


### PR DESCRIPTION
…an error in that file.

Emacs's `compilation-mode` has a function `next-error` that works well after this change.